### PR TITLE
Fix indexing error in retrace operation of ACER

### DIFF
--- a/acer.py
+++ b/acer.py
@@ -25,89 +25,96 @@ class ReplayBuffer():
 
     def put(self, seq_data):
         self.buffer.append(seq_data)
-    
+
     def sample(self, on_policy=False):
         if on_policy:
             mini_batch = [self.buffer[-1]]
         else:
             mini_batch = random.sample(self.buffer, batch_size)
 
-        s_lst, a_lst, r_lst, prob_lst, done_lst, is_first_lst = [], [], [], [], [], []
+        s_lst, a_lst, r_lst, s_nxt_lst, prob_lst, done_lst, is_first_lst = [], [], [], [], [], [], []
         for seq in mini_batch:
             is_first = True  # Flag for indicating whether the transition is the first item from a sequence
             for transition in seq:
-                s, a, r, prob, done = transition
+                s, a, r, s_nxt, prob, done = transition
 
                 s_lst.append(s)
                 a_lst.append([a])
                 r_lst.append(r)
+                s_nxt_lst.append(s_nxt)
                 prob_lst.append(prob)
-                done_mask = 0.0 if done else 1.0
-                done_lst.append(done_mask)
+                done_lst.append(0.0 if done else 1.0)
                 is_first_lst.append(is_first)
                 is_first = False
 
-        s,a,r,prob,done_mask,is_first = torch.tensor(s_lst, dtype=torch.float), torch.tensor(a_lst), \
-                                        r_lst, torch.tensor(prob_lst, dtype=torch.float), done_lst, \
-                                        is_first_lst
-        return s,a,r,prob,done_mask,is_first
-    
+        s, a, r, s_nxt, prob, done_mask, is_first = torch.tensor(s_lst, dtype=torch.float), \
+                                                    torch.tensor(a_lst), r_lst, \
+                                                    torch.tensor(s_nxt_lst, dtype=torch.float), \
+                                                    torch.tensor(prob_lst, dtype=torch.float), \
+                                                    done_lst, is_first_lst
+        return s, a, r, s_nxt, prob, done_mask, is_first
+
     def size(self):
         return len(self.buffer)
-      
+
 class ActorCritic(nn.Module):
     def __init__(self):
         super(ActorCritic, self).__init__()
-        self.fc1 = nn.Linear(4,256)
-        self.fc_pi = nn.Linear(256,2)
-        self.fc_q = nn.Linear(256,2)
-        
+        self.fc1 = nn.Linear(4, 256)
+        self.fc_pi = nn.Linear(256, 2)
+        self.fc_q = nn.Linear(256, 2)
+
     def pi(self, x, softmax_dim = 0):
         x = F.relu(self.fc1(x))
         x = self.fc_pi(x)
         pi = F.softmax(x, dim=softmax_dim)
         return pi
-    
+
     def q(self, x):
         x = F.relu(self.fc1(x))
         q = self.fc_q(x)
         return q
       
 def train(model, optimizer, memory, on_policy=False):
-    s,a,r,prob,done_mask,is_first = memory.sample(on_policy)
+    s, a, r, s_nxt, prob, done_mask, is_first = memory.sample(on_policy)
     
     q = model.q(s)
-    q_a = q.gather(1,a)
-    pi = model.pi(s, softmax_dim = 1)
-    pi_a = pi.gather(1,a)
+    q_a = q.gather(1, a)
+    pi = model.pi(s, softmax_dim=1)
+    pi_a = pi.gather(1, a)
     v = (q * pi).sum(1).unsqueeze(1).detach()
-    
+
+    # In same episode, s_nxt[i-1] == s[i]
+    q_nxt = model.q(s_nxt)
+    pi_nxt = model.pi(s_nxt, softmax_dim=1)
+    v_nxt = (q_nxt * pi_nxt).sum(1, keepdim=True).detach()
+
     rho = pi.detach()/prob
-    rho_a = rho.gather(1,a)
+    rho_a = rho.gather(1, a)
     rho_bar = rho_a.clamp(max=c)
     correction_coeff = (1-c/rho).clamp(min=0)
 
-    q_ret = v[-1] * done_mask[-1]
+    q_ret = v_nxt[-1] * done_mask[-1]
     q_ret_lst = []
     for i in reversed(range(len(r))):
         q_ret = r[i] + gamma * q_ret
         q_ret_lst.append(q_ret.item())
         q_ret = rho_bar[i] * (q_ret - q_a[i]) + v[i]
-        
+
         if is_first[i] and i!=0:
-            q_ret = v[i-1] * done_mask[i-1] # When a new sequence begins, q_ret is initialized  
-            
+            q_ret = v_nxt[i-1] * done_mask[i-1] # When a new sequence begins, q_ret is initialized  
+
     q_ret_lst.reverse()
     q_ret = torch.tensor(q_ret_lst, dtype=torch.float).unsqueeze(1)
-    
+
     loss1 = -rho_bar * torch.log(pi_a) * (q_ret - v) 
     loss2 = -correction_coeff * pi.detach() * torch.log(pi) * (q.detach()-v) # bias correction term
     loss = loss1 + loss2.sum(1) + F.smooth_l1_loss(q_a, q_ret)
-    
+
     optimizer.zero_grad()
     loss.mean().backward()
     optimizer.step()
-        
+
 def main():
     env = gym.make('CartPole-v1')
     memory = ReplayBuffer()
@@ -120,26 +127,26 @@ def main():
     for n_epi in range(10000):
         s = env.reset()
         done = False
-        
+
         while not done:
             seq_data = []
             for t in range(rollout_len): 
                 prob = model.pi(torch.from_numpy(s).float())
                 a = Categorical(prob).sample().item()
-                s_prime, r, done, info = env.step(a)
-                seq_data.append((s, a, r/100.0, prob.detach().numpy(), done))
+                s_nxt, r, done, info = env.step(a)
+                seq_data.append((s, a, r/100.0, s_nxt, prob.detach().numpy(), done))
 
-                score +=r
-                s = s_prime
+                score += r
+                s = s_nxt
                 if done:
                     break
-                    
+
             memory.put(seq_data)
-            if memory.size()>500:
+            if memory.size() > 500:
                 train(model, optimizer, memory, on_policy=True)
                 train(model, optimizer, memory)
-        
-        if n_epi%print_interval==0 and n_epi!=0:
+
+        if n_epi % print_interval == 0 and n_epi != 0:
             print("# of episode :{}, avg score : {:.1f}, buffer size : {}".format(n_epi, score/print_interval, memory.size()))
             score = 0.0
 


### PR DESCRIPTION
In ACER, when calculating the Retrace target term for i-th state, one must use the value(or retrace target) of (i+1)-th state.

For example, ```Q_ret[k-1]``` should be ```r[k-1] + gamma * v[k]```.
![image](https://user-images.githubusercontent.com/7707859/62287858-0300f800-b496-11e9-8bac-b6f822d27577.png)

But current implementation seems using ```v[i]``` instead of ```v[i+1]``` when calculating ```Q_ret[i]```.

As the original code put the experience from different episodes into one batch, the simplest solution would be adding next state information to experience tuple.

-----

ACER에서 i번째 상태에 대한 Retrace target을 계산할 땐 i+1번째 상태의 value function(또는 Retrace[i+1])에 discount factor를 곱해서 계산하는 것으로 알고 있는데, 현재 코드 상으로는 다음 상태의 Value 값이 아니라 현재 상태의 Value 값을 쓰는 것으로 보입니다.

예를 들어 한 에피소드의 0부터 k번째 상태가 주어졌을 때, k-1번째 상태의 retrace 값을 계산할 때는 ```Q_ret[k-1] = r[k-1] + gamma * v[k]``` 으로 계산되어야 하는데 현재 코드에서는 ```v[k-1]```이 들어가는 것 같습니다.

메모리를 절약하기 위해선 주어진 rollout의 마지막 상태를 value function 계산 용도로만 사용하고 뉴럴넷의 학습은 마지막 상태를 제외한 데이터에 대해 진행하면 좋겠지만, 현재 구현에선 한 배치에 여러 에피소드의 데이터가 같이 들어가기 때문에 구현의 단순화를 위해 그냥 모든 상태에 대해 다음 상태를 함께 저장하게 했습니다.

혹시 틀린 부분이나 개선 가능한 점이 있으면 말씀해주세요!
