### PR TITLE
Remove redundant while loop break in dqn.py

### DIFF
--- a/dqn.py
+++ b/dqn.py
@@ -98,8 +98,6 @@ def main():
             s = s_prime
 
             score += r
-            if done:
-                break
             
         if memory.size()>2000:
             train(q, q_target, memory, optimizer)


### PR DESCRIPTION
The training loop in dqn.py has both `while not done` and `if done: break`. This is harmless, but redundant. Given this repo's focus on minimalism, though, I thought the break statement should be removed.